### PR TITLE
fix: add missing site favicon to head

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BLT Jobs - Connect Talent with Opportunities</title>
     <meta name="description" content="A community-driven job board for the OWASP BLT ecosystem. Post a job or feature your profile to connect with talent." />
-    <link rel="icon" href="./assets/images/blt-logo.png" type="image/x-icon">
+    <link rel="icon" href="./assets/images/blt-logo.png" type="image/png">
 
     <!-- Open Graph Metadata -->
     <meta property="og:title" content="BLT Jobs - Connect Talent with Opportunities" />

--- a/index.html
+++ b/index.html
@@ -5,13 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BLT Jobs - Connect Talent with Opportunities</title>
     <meta name="description" content="A community-driven job board for the OWASP BLT ecosystem. Post a job or feature your profile to connect with talent." />
-    
+    <link rel="icon" href="./assets/images/blt-logo.png" type="image/x-icon">
+
     <!-- Open Graph Metadata -->
     <meta property="og:title" content="BLT Jobs - Connect Talent with Opportunities" />
     <meta property="og:description" content="A community-driven job board for the OWASP BLT ecosystem. Post a job or feature your profile to connect with talent." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://owasp-blt.github.io/BLT-Jobs/" />
-    
+
     <!-- Twitter Card Metadata -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="BLT Jobs - Connect Talent with Opportunities" />


### PR DESCRIPTION
### Simplified PR Description

**Summary:** 
Added a missing favicon to `index.html` to ensure the site logo appears in the browser tab.

**Changes:**
* Added `<link rel="icon"...>` to the document head.

**Status:**
- [x] Tested locally (logo appears)
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a favicon to the application that displays the BLT logo in browser tabs and bookmarks.
  * This change is cosmetic only; no user-facing functionality, API, or public interface changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->